### PR TITLE
Changed parser to html.parser

### DIFF
--- a/eztv_api.py
+++ b/eztv_api.py
@@ -90,7 +90,7 @@ class EztvAPI(object):
 
         req = requests.get(URL, timeout=5)
 
-        soup = BeautifulSoup(req.content)
+        soup = BeautifulSoup(req.content, 'html.parser')
         tv_shows = str(
             soup('select', {'name': 'SearchString'})).split('</option>')
         for tv_show in tv_shows:
@@ -120,7 +120,7 @@ class EztvAPI(object):
                    'SearchString1': '', 'search': 'Search'}
 
         req = requests.post(url, data=payload, timeout=5)
-        soup = BeautifulSoup(req.content)
+        soup = BeautifulSoup(req.content, 'html.parser')
 
         self._season_and_episode = {}
         episodes = str(soup('a', {'class': 'magnet'})).split('</a>')


### PR DESCRIPTION
Some pages were not getting parsed properly (most likely due to some broken html). For example: '2 broke girls' and 'the cleveland show' did not work, mostly episodes further down the page.

Changed the parser BeautifulSoup uses to be more error friendly.
